### PR TITLE
Add a .sync option to Loggers

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -2,6 +2,8 @@ module ManageIQ
   module Loggers
     class Container < Base
       def initialize(logdev = STDOUT, *args)
+        logdev.sync = true # Don't buffer container log output
+
         super
         self.level = DEBUG
         self.formatter = Formatter.new


### PR DESCRIPTION
Add an option to ManageIQ::Loggers to control the underlying logdev
device buffering and default container logger to true.