### PR TITLE
Remove bundler dependency

### DIFF
--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport",     ">= 5.0"
   spec.add_runtime_dependency "manageiq-password", "~> 0.1"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
I'd also be fine having an open-ended dependency, but locking to v1 is annoying and I don't the the reasoning behind having this here.