### PR TITLE
Journald message improvements

### DIFF
--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -52,19 +52,27 @@ module ManageIQ
       #
       def determine_identifier(message)
         case message
-        when /amazon/i
+        when /Amazon/
           'cfme-aws'
-        when /azure/i
+        when /Azure/
           'cfme-azure'
-        when /google/i
+        when /Google/
           'cfme-google'
-        when /openshift/i
-          'cfme-openshift'
-        when /openstack/i
-          'cfme-openstack'
-        when /microsoft|scvmm/i
+        when /Kubernetes/
+          'cfme-kubernetes'
+        when /Kubevirt/
+          'cfme-kubevirt'
+        when /Microsoft/
           'cfme-scvmm'
-        when /vmware/i
+        when /Nuage/
+          'cfme-nuage'
+        when /Openshift/
+          'cfme-openshift'
+        when /Openstack/
+          'cfme-openstack'
+        when /Redhat/
+          'cfme-ovirt'
+        when /Vmware/
           'cfme-vmware'
         else
           'cmfe'

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -1,9 +1,6 @@
 module ManageIQ
   module Loggers
     class Journald < Base
-      # An identifier passed on to the logger message. The default is 'manageiq'.
-      attr_accessor :application
-
       # The syslog facility used when writing messages. The default is 'local3'.
       attr_accessor :syslog_facility
 
@@ -21,7 +18,6 @@ module ManageIQ
         super(logdev, *args)
         @formatter = Formatter.new
         @progname ||= 'manageiq'
-        @application ||= 'manageiq'
         @syslog_facility ||= 'local3'
         @syslog_identifier ||= @progname
       end
@@ -58,7 +54,6 @@ module ManageIQ
         Systemd::Journal.message(
           :message           => message,
           :priority          => log_level_map[severity],
-          :application       => application,
           :syslog_identifier => syslog_identifier,
           :syslog_facility   => syslog_facility,
           :code_line         => caller_object.lineno,

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -51,7 +51,7 @@ module ManageIQ
           :message           => message,
           :message_id        => message_id,
           :priority          => log_level_map[severity],
-          :application       => 'cfme',
+          :application       => 'manageiq',
           :syslog_identifier => determine_identifier(message),
           :syslog_facility   => 'local3',
           :code_line         => caller_object.lineno,
@@ -68,29 +68,29 @@ module ManageIQ
       def determine_identifier(message)
         case message
         when /Amazon/
-          'cfme-aws'
+          'manageiq-aws'
         when /Azure/
-          'cfme-azure'
+          'manageiq-azure'
         when /Google/
-          'cfme-google'
+          'manageiq-google'
         when /Kubernetes/
-          'cfme-kubernetes'
+          'manageiq-kubernetes'
         when /Kubevirt/
-          'cfme-kubevirt'
+          'manageiq-kubevirt'
         when /Microsoft/
-          'cfme-scvmm'
+          'manageiq-scvmm'
         when /Nuage/
-          'cfme-nuage'
+          'manageiq-nuage'
         when /Openshift/
-          'cfme-openshift'
+          'manageiq-openshift'
         when /Openstack/
-          'cfme-openstack'
+          'manageiq-openstack'
         when /Redhat/
-          'cfme-ovirt'
+          'manageiq-ovirt'
         when /Vmware/
-          'cfme-vmware'
+          'manageiq-vmware'
         else
-          'cmfe'
+          'manageiq'
         end
       end
 

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -46,6 +46,7 @@ module ManageIQ
         message = formatter.call(format_severity(severity), progname, message)
         caller_object = caller_locations.last
 
+        # TODO: Allow the syslog facility to be set via the configuration settings.
         Systemd::Journal.message(
           :message           => message,
           :message_id        => message_id,

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -1,9 +1,6 @@
 module ManageIQ
   module Loggers
     class Journald < Base
-      # The syslog facility used when writing messages. The default is 'local3'.
-      attr_accessor :syslog_facility
-
       # An syslog identifier used when writing messages. The default is the progname.
       attr_accessor :syslog_identifier
 
@@ -18,7 +15,6 @@ module ManageIQ
         super(logdev, *args)
         @formatter = Formatter.new
         @progname ||= 'manageiq'
-        @syslog_facility ||= 'local3'
         @syslog_identifier ||= @progname
       end
 
@@ -50,12 +46,10 @@ module ManageIQ
         message = formatter.call(format_severity(severity), progname, message)
         caller_object = caller_locations.last
 
-        # TODO: Allow the syslog facility to be set via the configuration settings.
         Systemd::Journal.message(
           :message           => message,
           :priority          => log_level_map[severity],
           :syslog_identifier => syslog_identifier,
-          :syslog_facility   => syslog_facility,
           :code_line         => caller_object.lineno,
           :code_file         => caller_object.absolute_path
         )

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -37,7 +37,7 @@ module ManageIQ
           :message_id        => message_id,
           :priority          => log_level_map[severity],
           :application       => 'cfme',
-          :syslog_identifier => 'cfme',
+          :syslog_identifier => determine_identifier(message),
           :syslog_facility   => 'local3',
           :code_line         => caller_object.lineno,
           :code_file         => caller_object.absolute_path
@@ -45,6 +45,31 @@ module ManageIQ
       end
 
       private
+
+      # Determine the identifier based on the message. Ideally this would
+      # be set by the provider once we have pluggable loggers, but for now
+      # we parse the message.
+      #
+      def determine_identifier(message)
+        case message
+        when /amazon/i
+          'cfme-aws'
+        when /azure/i
+          'cfme-azure'
+        when /google/i
+          'cfme-google'
+        when /openshift/i
+          'cfme-openshift'
+        when /openstack/i
+          'cfme-openstack'
+        when /microsoft|scvmm/i
+          'cfme-scvmm'
+        when /vmware/i
+          'cfme-vmware'
+        else
+          'cmfe'
+        end
+      end
 
       def log_level_map
         @log_level_map ||= {

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -21,6 +21,7 @@ module ManageIQ
         super(logdev, *args)
         @formatter = Formatter.new
         @progname ||= 'manageiq'
+        @application ||= 'manageiq'
         @syslog_facility ||= 'local3'
         @syslog_identifier ||= @progname
       end

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -1,25 +1,22 @@
-
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "manageiq/loggers/version"
+require "rbconfig"
+require_relative "lib/manageiq/loggers/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "manageiq-loggers"
-  spec.version       = ManageIQ::Loggers::VERSION
-  spec.authors       = ["ManageIQ Authors"]
-
-  spec.summary       = %q{Loggers for ManageIQ projects}
-  spec.homepage      = "https://github.com/ManageIQ/manageiq-loggers"
-  spec.licenses      = ["Apache-2.0"]
+  spec.name     = "manageiq-loggers"
+  spec.version  = ManageIQ::Loggers::VERSION
+  spec.authors  = ["ManageIQ Authors"]
+  spec.summary  = %q{Loggers for ManageIQ projects}
+  spec.homepage = "https://github.com/ManageIQ/manageiq-loggers"
+  spec.licenses = ["Apache-2.0"]
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+
+  spec.bindir      = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
   spec.add_runtime_dependency "activesupport",     ">= 5.0"
   spec.add_runtime_dependency "manageiq-password", "~> 0.1"
@@ -29,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "systemd-journal" if RbConfig::CONFIG['host_os'] =~ /linux/i
 end

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "cloudwatchlogger"
+  spec.add_development_dependency "systemd-journal"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -1,22 +1,26 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "manageiq/loggers/version"
 require "rbconfig"
-require_relative "lib/manageiq/loggers/version"
 
 Gem::Specification.new do |spec|
-  spec.name     = "manageiq-loggers"
-  spec.version  = ManageIQ::Loggers::VERSION
-  spec.authors  = ["ManageIQ Authors"]
-  spec.summary  = %q{Loggers for ManageIQ projects}
-  spec.homepage = "https://github.com/ManageIQ/manageiq-loggers"
-  spec.licenses = ["Apache-2.0"]
+  spec.name          = "manageiq-loggers"
+  spec.version       = ManageIQ::Loggers::VERSION
+  spec.authors       = ["ManageIQ Authors"]
+
+  spec.summary       = %q{Loggers for ManageIQ projects}
+  spec.homepage      = "https://github.com/ManageIQ/manageiq-loggers"
+  spec.licenses      = ["Apache-2.0"]
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-
-  spec.bindir      = "exe"
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport",     ">= 5.0"
   spec.add_runtime_dependency "manageiq-password", "~> 0.1"

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "cloudwatchlogger"
-  spec.add_development_dependency "systemd-journal"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,0 +1,45 @@
+require 'manageiq/loggers/journald'
+
+RSpec.describe ManageIQ::Loggers::Journald do
+  let(:logger) { described_class.new }
+
+  context "application accessor" do
+    it "has an application accessor" do
+      expect(logger).to respond_to(:application)
+      expect(logger).to respond_to(:application=)
+    end
+
+    it "sets the default application to manageiq" do
+      expect(logger.application).to eql('manageiq')
+    end
+  end
+
+  context "progname" do
+    it "sets the progname to manageiq by default" do
+      expect(logger.progname).to eql('manageiq')
+    end
+  end
+
+  context "syslog_facility accessor" do
+    it "has a syslog_facility accessor" do
+      expect(logger).to respond_to(:syslog_facility)
+      expect(logger).to respond_to(:syslog_facility=)
+    end
+
+    it "sets the default syslog_facility to local3" do
+      expect(logger.syslog_facility).to eql('local3')
+    end
+  end
+
+  context "syslog_identifier accessor" do
+    it "has a syslog_identifier accessor" do
+      expect(logger).to respond_to(:syslog_identifier)
+      expect(logger).to respond_to(:syslog_identifier=)
+    end
+
+    it "sets the syslog_identifier to the progname by default" do
+      logger = ManageIQ::Loggers::Journald.new(nil, :progname => 'manageiq-test')
+      expect(logger.syslog_identifier).to eql('manageiq-test')
+    end
+  end
+end

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,6 +1,6 @@
 require 'manageiq/loggers/journald'
 
-RSpec.describe ManageIQ::Loggers::Journald do
+RSpec.describe ManageIQ::Loggers::Journald, :systemd do
   let(:logger) { described_class.new }
 
   context "application accessor" do

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -9,17 +9,6 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
     end
   end
 
-  context "syslog_facility accessor" do
-    it "has a syslog_facility accessor" do
-      expect(logger).to respond_to(:syslog_facility)
-      expect(logger).to respond_to(:syslog_facility=)
-    end
-
-    it "sets the default syslog_facility to local3" do
-      expect(logger.syslog_facility).to eql('local3')
-    end
-  end
-
   context "syslog_identifier accessor" do
     it "has a syslog_identifier accessor" do
       expect(logger).to respond_to(:syslog_identifier)

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -3,17 +3,6 @@ require 'manageiq/loggers/journald'
 RSpec.describe ManageIQ::Loggers::Journald, :systemd do
   let(:logger) { described_class.new }
 
-  context "application accessor" do
-    it "has an application accessor" do
-      expect(logger).to respond_to(:application)
-      expect(logger).to respond_to(:application=)
-    end
-
-    it "sets the default application to manageiq" do
-      expect(logger.application).to eql('manageiq')
-    end
-  end
-
   context "progname" do
     it "sets the progname to manageiq by default" do
       expect(logger.progname).to eql('manageiq')

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,6 +1,6 @@
 require 'manageiq/loggers/journald'
 
-RSpec.describe ManageIQ::Loggers::Journald, :systemd do
+RSpec.describe ManageIQ::Loggers::Journald, :linux do
   let(:logger) { described_class.new }
 
   context "progname" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ end
 
 require "bundler/setup"
 require "manageiq-loggers"
+require "rbconfig"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -12,5 +13,9 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  if RbConfig::CONFIG["host_os"] !~ /linux/
+    config.filter_run_excluding(:linux => true)
   end
 end


### PR DESCRIPTION
Rather than using a simple `Systemd::Journal.print` for logging messages, I'd like to take advantage of  of the `Systemd::Journal.message` method, which lets us set various attributes.

Specifically, I'd like to set the following attributes for the following reasons:

* **syslog_identifier** - A trusted field that can be used by the `journal -t` option to filter logs by provider, as well as potential rsyslog configuration.
* ~~* **syslog_facility** - Another trusted field that could provide a way to query for ManageIQ related log entries, and another potential hook for rsyslog configuration.~~
* ~~**application** - Potentially useful as a way to get all manageiq related messages.~~
* **code_line** - Another trusted field we can use to show what generated the log entry.
* **code_file** - Another trusted field we can use to show what file generated the log entry.
* ~~**message_id** - Another trusted field we can use to uniquely identify the logger instance.~~

Possible questions:

Q) Why "local3"?
A) Because it's one of the unused rsyslog facilities, which would make filtering both journald and (potentially) rsyslog easier. Ideally, this would be configurable via a setting, but for now I just set it as a default that can be changed in the constructor if desired.

Q) Why add a message ID?
A) I added it after reading http://0pointer.de/blog/projects/journal-submit.html, which indicated that it could be useful as a way of identifying messages, although I admit that here I'm using it to identify this logger instance, rather than specific messages. But, it still might be useful as a way to identify different log entry origins.
U) Nevermind, we've decided to drop this.

Q) What sort of things can you do with this?
A) The most likely filter would be stuff like `journalctl -t manageiq-azure -o json-pretty`, for example, to get a list of Azure provider related log entries, or `journalctl APPLICATION=manageiq` or `journalctl -u evmserverd` to get all ManageIQ related log messages.

For a list of trusted fields:

http://0pointer.de/public/systemd-man/systemd.journal-fields.html

~~WIP for now, as I'm looking for feedback. It also looks like this logger needs some specs.~~

Update: added some basic specs, which also required updating the gemspec.