### PR TITLE
Specify a rubocop channel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,3 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
+    channel: 'rubocop-0-69'


### PR DESCRIPTION
See ManageIQ/manageiq#18840 for more information

Unfortunately there's no way to use a centralized .codeclimate, so we have to configure the configuration files individually.