### PR TITLE
Fix case in version file, freeze version constant

### DIFF
--- a/lib/manageiq/loggers/version.rb
+++ b/lib/manageiq/loggers/version.rb
@@ -1,5 +1,5 @@
-module Manageiq
+module ManageIQ
   module Loggers
-    VERSION = "0.4.0"
+    VERSION = "0.4.0".freeze
   end
 end

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -5,7 +5,7 @@ require "manageiq/loggers/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "manageiq-loggers"
-  spec.version       = Manageiq::Loggers::VERSION
+  spec.version       = ManageIQ::Loggers::VERSION
   spec.authors       = ["ManageIQ Authors"]
 
   spec.summary       = %q{Loggers for ManageIQ projects}


### PR DESCRIPTION
It looks like `Manageiq::Loggers::VERSION` should be `ManageIQ::Loggers::VERSION`, i.e. uppercase "IQ" at the end.

Also, I froze the constant, and updated the gemspec to match the change.