### PR TITLE
Revert "Change CloudWatch log_group to be the namespace if it exists"

### DIFF
--- a/lib/manageiq/loggers/cloud_watch.rb
+++ b/lib/manageiq/loggers/cloud_watch.rb
@@ -9,8 +9,7 @@ module ManageIQ
       def self.new(*args)
         access_key_id     = ENV["CW_AWS_ACCESS_KEY_ID"].presence
         secret_access_key = ENV["CW_AWS_SECRET_ACCESS_KEY"].presence
-        namespace         = File.exist?(NAMESPACE_FILE) ? File.read(NAMESPACE_FILE) : nil
-        log_group_name    = namespace || ENV["CLOUD_WATCH_LOG_GROUP"].presence
+        log_group_name    = ENV["CLOUD_WATCH_LOG_GROUP"].presence
         log_stream_name   = ENV["HOSTNAME"].presence
 
         container_logger = ManageIQ::Loggers::Container.new

--- a/spec/manageiq/cloud_watch_spec.rb
+++ b/spec/manageiq/cloud_watch_spec.rb
@@ -24,8 +24,6 @@ describe ManageIQ::Loggers::CloudWatch do
 
     before do
       expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new).and_return(double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager", :deliver => nil))
-      expect(File).to receive(:exist?).with(described_class::NAMESPACE_FILE).and_return(true)
-      expect(File).to receive(:read).with(described_class::NAMESPACE_FILE).and_return("abc")
     end
 
     it "returns a CloudWatch::Client" do


### PR DESCRIPTION
This reverts commit 772ae8f5027bafd210d579a081114c31f5ccc9e7.

log_group needs to be "platform" or "platform-dev" in order to have the correct permissions, switch back to preferring the ENV var.
RHIOPS-544