### PR TITLE
Use Thread.current[:request_id] for logging request_id

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -64,7 +64,11 @@ module ManageIQ
         end
 
         def request_id
-          Thread.current[:current_request]&.request_id
+          if Thread.current[:current_request]&.request_id
+            ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+          end
+
+          Thread.current[:current_request]&.request_id || Thread.current[:request_id]
         end
       end
     end


### PR DESCRIPTION
TPINVTRY-838

we need a way how to populate request-id In services without server.

needed for : 