### PR TITLE
Fix the handling of journald code_file/code_line

### DIFF
--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -44,7 +44,7 @@ module ManageIQ
         end
 
         message = formatter.call(format_severity(severity), progname, message)
-        caller_object = caller_locations.last
+        caller_object = caller_locations(3, 1).first
 
         Systemd::Journal.message(
           :message           => message,


### PR DESCRIPTION
The caller_locations was incorrectly jumping to the bottom of the stack rather than the top of it, and thus was returning e.g. `bin/rails` as the calling file instead of the actual source file.

The top of the stack looks like:
```
caller location 0: /home/grare/adam/src/manageiq/manageiq-loggers/lib/manageiq/loggers/journald.rb:50:in `add'
caller location 1: /home/grare/adam/.gems/2.7.0/gems/activesupport-5.2.4.3/lib/active_support/logger.rb:27:in `block (2 levels) in broadcast'
caller location 2: /usr/lib/ruby/2.7.0/logger.rb:546:in `error'
caller location 3: /home/grare/adam/src/manageiq/manageiq/app/models/ext_management_system.rb:46:in `testing'
```

cc @djberg96 