### PR TITLE
Add code_func

### DIFF
--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -51,7 +51,8 @@ module ManageIQ
           :priority          => log_level_map[severity],
           :syslog_identifier => syslog_identifier,
           :code_line         => caller_object.lineno,
-          :code_file         => caller_object.absolute_path
+          :code_file         => caller_object.absolute_path,
+          :code_func         => caller_object.label
         )
       end
 


### PR DESCRIPTION
Turns out there's also a `code_func` field in journald we can use. This PR updates the logging message to include it, via the `label` method.

https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html