### PR TITLE
Make Container Logger respect `level=`, defaulting to DEBUG so we can lower log level if necessary

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -9,8 +9,9 @@ module ManageIQ
         self.formatter = Formatter.new
       end
 
-      def level=(_new_level)
-        super(DEBUG) # We want everything written to the ContainerLogger written to STDOUT
+      # Default to DEBUG, but allow changing via this method.
+      def level=(new_level = DEBUG)
+        super(new_level) # We want everything written to the ContainerLogger written to STDOUT
       end
 
       def filename


### PR DESCRIPTION
Found when trying to lower the loglevel across topology collectors/operations workers - trying to set the log level with `level=` was not working, and upon further inspection it appears we can have "any log level we want as long as it's debug". 

This change just defaults the `level=` to `DEBUG`, but still passes through the change if we do want to specify a different level e.g. WARN. This is so we can reduce our CloudWatch logs on the pieces that don't quite need firehose-level visibility. 

cc @syncrou @gmcculloug 