### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: ruby
-sudo: false
 cache: bundler
 rvm:
 - 2.4.5


### PR DESCRIPTION
we no longer need `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration