### PR TITLE
Fix ActiveSupport::Deprecation call

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -64,11 +64,12 @@ module ManageIQ
         end
 
         def request_id
-          if Thread.current[:current_request]&.request_id
-            ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+          Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
+            if request_id
+              require "active_support/deprecation"
+              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+            end
           end
-
-          Thread.current[:current_request]&.request_id || Thread.current[:request_id]
         end
       end
     end

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -1,28 +1,56 @@
 require 'manageiq/loggers/container'
 
 describe ManageIQ::Loggers::Container::Formatter do
-  let(:request_id) { "123" }
-  let(:request) { double(:request_id => request_id) }
-  before do
-    Thread.current[:current_request] = request
-  end
-  after do
-    Thread.current[:current_request] = nil
-  end
+  let(:message) { "testing 1, 2, 3" }
 
-  it "stuff" do
-    time = Time.now
-    result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
-    expected = {
+  def expected_hash(time, message, request_id = nil)
+    {
       "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
       "hostname"   => ENV["HOSTNAME"],
       "level"      => "info",
-      "message"    => "testing 1, 2, 3",
+      "message"    => message,
       "pid"        => $PROCESS_ID,
       "service"    => "some_program",
       "tid"        => Thread.current.object_id.to_s(16),
       "request_id" => request_id
     }.compact
+  end
+
+  describe "with a request_id in thread local storage" do
+    let(:request_id) { "123" }
+
+    context "in :request_id" do
+      before { Thread.current[:request_id] = request_id }
+      after  { Thread.current[:request_id] = nil }
+
+      it do
+        time = Time.now
+        result = described_class.new.call("INFO", time, "some_program", message)
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+
+    context "in deprecated :current_request" do
+      before { Thread.current[:current_request] = double(:request_id => request_id) }
+      after  { Thread.current[:current_request] = nil }
+
+      it do
+        require "active_support/deprecation"
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+
+        time = Time.now
+        result = described_class.new.call("INFO", time, "some_program", message)
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+  end
+
+  it "logs a message" do
+    time = Time.now
+    result = described_class.new.call("INFO", time, "some_program", message)
+    expected = expected_hash(time, message)
     expect(JSON.parse(result)).to eq(expected)
   end
 end


### PR DESCRIPTION
This call currently fails in specs because active_support/deprecation
was never required.  This commit adds in that, and also tests that
behavior.

Additionally, this prefers :request_id in thead local storage over
:current_request if both happen to be present, so as not to incur the
loading of active_support/deprecation in the normal case.

@bdunne Please review.  This should fix the current broken specs.