### PR TITLE
Fix escaping of < and > in Container logger

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -64,11 +64,12 @@ module ManageIQ
         end
 
         def request_id
-          if Thread.current[:current_request]&.request_id
-            ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+          Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
+            if request_id
+              require "active_support/deprecation"
+              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+            end
           end
-
-          Thread.current[:current_request]&.request_id || Thread.current[:request_id]
         end
       end
     end

--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -36,7 +36,7 @@ module ManageIQ
         def call(severity, time, progname, msg)
           # From https://github.com/ViaQ/elasticsearch-templates/releases -> Downloads -> *.asciidoc
           # NOTE: These values are in a specific order for easier human readbility via STDOUT
-          {
+          payload = {
             :@timestamp => format_datetime(time),
             :hostname   => hostname,
             :pid        => $PROCESS_ID,
@@ -46,7 +46,8 @@ module ManageIQ
             :message    => prefix_task_id(msg2str(msg)),
             :request_id => request_id
             # :tags => "tags string",
-          }.compact.to_json << "\n"
+          }.compact
+          JSON.generate(payload) << "\n"
         end
 
         private

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -53,4 +53,12 @@ describe ManageIQ::Loggers::Container::Formatter do
     expected = expected_hash(time, message)
     expect(JSON.parse(result)).to eq(expected)
   end
+
+  it "does not escape characters as in ActiveSupport::JSON extensions" do
+    require "active_support/json"
+
+    time = Time.now
+    result = described_class.new.call("INFO", time, "some_program", "xxx < yyy > zzz")
+    expect(result).to include('"message":"xxx < yyy > zzz"')
+  end
 end

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -1,28 +1,56 @@
 require 'manageiq/loggers/container'
 
 describe ManageIQ::Loggers::Container::Formatter do
-  let(:request_id) { "123" }
-  let(:request) { double(:request_id => request_id) }
-  before do
-    Thread.current[:current_request] = request
-  end
-  after do
-    Thread.current[:current_request] = nil
-  end
+  let(:message) { "testing 1, 2, 3" }
 
-  it "stuff" do
-    time = Time.now
-    result = described_class.new.call("INFO", time, "some_program", "testing 1, 2, 3")
-    expected = {
+  def expected_hash(time, message, request_id = nil)
+    {
       "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
       "hostname"   => ENV["HOSTNAME"],
       "level"      => "info",
-      "message"    => "testing 1, 2, 3",
+      "message"    => message,
       "pid"        => $PROCESS_ID,
       "service"    => "some_program",
       "tid"        => Thread.current.object_id.to_s(16),
       "request_id" => request_id
     }.compact
+  end
+
+  describe "with a request_id in thread local storage" do
+    let(:request_id) { "123" }
+
+    context "in :request_id" do
+      before { Thread.current[:request_id] = request_id }
+      after  { Thread.current[:request_id] = nil }
+
+      it do
+        time = Time.now
+        result = described_class.new.call("INFO", time, "some_program", message)
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+
+    context "in deprecated :current_request" do
+      before { Thread.current[:current_request] = double(:request_id => request_id) }
+      after  { Thread.current[:current_request] = nil }
+
+      it do
+        require "active_support/deprecation"
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+
+        time = Time.now
+        result = described_class.new.call("INFO", time, "some_program", message)
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+  end
+
+  it "logs a message" do
+    time = Time.now
+    result = described_class.new.call("INFO", time, "some_program", message)
+    expected = expected_hash(time, message)
     expect(JSON.parse(result)).to eq(expected)
   end
 end


### PR DESCRIPTION
Built on top of #28 so the specs can pass.

Similar to https://github.com/ManageIQ/manageiq/pull/20883, this fixes the weird escaping in the container logger.

Example:

Before

```json
[1] pry(main)> $container_log.info("xxx < yyy > zzz")
{"@timestamp":"2020-12-09T14:59:14.307800 ","pid":39458,"tid":"3fdc05c2ffd0","level":"info","message":"xxx \u003c yyy \u003e zzz"}
```

After

```json
[1] pry(main)> $container_log.info("xxx < yyy > zzz")
{"@timestamp":"2020-12-09T14:58:30.909153 ","pid":39417,"tid":"3fd6d382ffd4","level":"info","message":"xxx < yyy > zzz"}
```

@bdunne Please review.
