### PR TITLE
Truncate log lines to 8Kb

### DIFF
--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -7,7 +7,7 @@ require 'English'
 module ManageIQ
   module Loggers
     class Base < Logger
-      MAX_LOG_LINE_LENGTH = 1.megabyte
+      MAX_LOG_LINE_LENGTH = 8.kilobytes
 
       def initialize(*args)
         super

--- a/spec/manageiq/base_spec.rb
+++ b/spec/manageiq/base_spec.rb
@@ -85,9 +85,9 @@ b:
     let(:logger) { described_class.new(@log) }
 
     it "truncates long messages when max_message_size is set" do
-      msg = "a" * 1_572_864 # 1.5 mb in bytes
+      msg = "a" * 10.kilobytes
       _, message = logger.formatter.call(:error, Time.now.utc, "", msg).split("-- : ")
-      expect(message.strip.size).to eq(1.megabyte)
+      expect(message.strip.size).to eq(8.kilobytes)
     end
   end
 end


### PR DESCRIPTION
A recent issue had log lines that were 30K, and even that was proving to
be too long and relatively useless. journald limits log line length to
about 8kb, so this feels like a reasonable value.

@agrare Please review.