### PR TITLE
Use progname rather than syslog_identifier for journald logs

### DIFF
--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -1,8 +1,10 @@
 module ManageIQ
   module Loggers
     class Journald < Base
-      # An syslog identifier used when writing messages. The default is the progname.
-      attr_accessor :syslog_identifier
+      require "active_support/core_ext/module/aliasing"
+
+      # Alias syslog_identifier for backwards compatibility
+      alias_attribute :syslog_identifier, :progname
 
       # Create and return a new ManageIQ::Loggers::Journald instance. The
       # arguments to the initializer can be ignored unless you're multicasting.
@@ -15,7 +17,6 @@ module ManageIQ
         super(logdev, *args)
         @formatter = Formatter.new
         @progname ||= 'manageiq'
-        @syslog_identifier ||= @progname
       end
 
       # Comply with the VMDB::Logger interface. For a filename we simply use
@@ -49,7 +50,7 @@ module ManageIQ
         Systemd::Journal.message(
           :message           => message,
           :priority          => log_level_map[severity],
-          :syslog_identifier => syslog_identifier,
+          :syslog_identifier => progname,
           :code_line         => caller_object.lineno,
           :code_file         => caller_object.absolute_path,
           :code_func         => caller_object.label

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -1,11 +1,6 @@
 module ManageIQ
   module Loggers
     class Journald < Base
-      require "active_support/core_ext/module/aliasing"
-
-      # Alias syslog_identifier for backwards compatibility
-      alias_attribute :syslog_identifier, :progname
-
       # Create and return a new ManageIQ::Loggers::Journald instance. The
       # arguments to the initializer can be ignored unless you're multicasting.
       #

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -4,20 +4,13 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
   let(:logger) { described_class.new }
 
   context "progname" do
+    it "has a progname accessor" do
+      expect(logger).to respond_to(:progname)
+      expect(logger).to respond_to(:progname=)
+    end
+
     it "sets the progname to manageiq by default" do
       expect(logger.progname).to eql('manageiq')
-    end
-  end
-
-  context "syslog_identifier accessor" do
-    it "has a syslog_identifier accessor" do
-      expect(logger).to respond_to(:syslog_identifier)
-      expect(logger).to respond_to(:syslog_identifier=)
-    end
-
-    it "sets the syslog_identifier to the progname by default" do
-      logger = ManageIQ::Loggers::Journald.new(nil, :progname => 'manageiq-test')
-      expect(logger.syslog_identifier).to eql('manageiq-test')
     end
   end
 


### PR DESCRIPTION
Make it simpler for callers to change the progname for all logger types by using progname rather than a different syslog identifier for journald logs.