### PR TITLE
Deprecate syslog_identifier in the journald logger 

### DIFF
--- a/lib/manageiq/loggers.rb
+++ b/lib/manageiq/loggers.rb
@@ -1,4 +1,5 @@
 require "manageiq/loggers/base"
 require "manageiq/loggers/cloud_watch"
 require "manageiq/loggers/container"
+require "manageiq/loggers/journald"
 require "manageiq/loggers/version"

--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -9,7 +9,7 @@ module ManageIQ
     class Base < Logger
       MAX_LOG_LINE_LENGTH = 8.kilobytes
 
-      def initialize(*args)
+      def initialize(*_, **_)
         super
         self.level = INFO
 

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -1,10 +1,14 @@
+require "active_support/core_ext/module/aliasing"
+require "active_support/deprecation"
+
 module ManageIQ
   module Loggers
     class Journald < Base
-      require "active_support/core_ext/module/aliasing"
-
-      # Alias syslog_identifier for backwards compatibility
       alias_attribute :syslog_identifier, :progname
+      ActiveSupport::Deprecation.new('v1.0', 'manageiq-loggers').deprecate_methods(self,
+        :syslog_identifier  => :progname,
+        :syslog_identifier= => :progname=,
+      )
 
       # Create and return a new ManageIQ::Loggers::Journald instance. The
       # arguments to the initializer can be ignored unless you're multicasting.

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -16,9 +16,9 @@ module ManageIQ
       # Internally we set our own formatter, and automatically set the
       # progname option to 'manageiq' if not specified.
       #
-      def initialize(logdev = nil, *args)
+      def initialize(logdev = nil, *_, **_)
         require "systemd-journal"
-        super(logdev, *args)
+        super
         @formatter = Formatter.new
         @progname ||= 'manageiq'
       end

--- a/spec/manageiq/cloud_watch_spec.rb
+++ b/spec/manageiq/cloud_watch_spec.rb
@@ -1,5 +1,4 @@
 require 'cloudwatchlogger'
-require 'manageiq/loggers/cloud_watch'
 
 describe ManageIQ::Loggers::CloudWatch do
   it "unconfigured returns a Container logger" do

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -1,5 +1,3 @@
-require 'manageiq/loggers/container'
-
 describe ManageIQ::Loggers::Container::Formatter do
   let(:message)   { "testing 1, 2, 3" }
   let(:formatter) { described_class.new }

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,5 +1,3 @@
-require 'manageiq/loggers/journald'
-
 RSpec.describe ManageIQ::Loggers::Journald, :linux do
   let(:logger) { described_class.new }
 

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -7,15 +7,23 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
     end
   end
 
-  context "syslog_identifier accessor" do
-    it "has a syslog_identifier accessor" do
-      expect(logger).to respond_to(:syslog_identifier)
-      expect(logger).to respond_to(:syslog_identifier=)
+  context "deprecated syslog_identifier accessor" do
+    it "sets the progname" do
+      logger.syslog_identifier = "manageiq-test"
+      expect(logger.syslog_identifier).to eq('manageiq-test')
+      expect(logger.progname).to          eq('manageiq-test')
     end
 
-    it "sets the syslog_identifier to the progname by default" do
-      logger = ManageIQ::Loggers::Journald.new(nil, :progname => 'manageiq-test')
-      expect(logger.syslog_identifier).to eql('manageiq-test')
+    it "is set by progname=" do
+      logger.progname = "manageiq-test"
+      expect(logger.syslog_identifier).to eq('manageiq-test')
+      expect(logger.progname).to          eq('manageiq-test')
+    end
+
+    it "is set by the progname on instantiation" do
+      logger = described_class.new(nil, :progname => 'manageiq-test')
+      expect(logger.syslog_identifier).to eq('manageiq-test')
+      expect(logger.progname).to          eq('manageiq-test')
     end
   end
 


### PR DESCRIPTION
This does a deprecation as opposed to removal as was done in dc4bc15, so
we can continue to release minor versions.

@agrare Please review.