### PR TITLE
Check if the global is defined before trying to use it

### DIFF
--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -151,7 +151,7 @@ module ManageIQ
 
         def prefix_task_id(msg)
           # Add task id to the message if a task is currently being worked on.
-          if (task_id = (Thread.current["tracking_label"] || $_miq_worker_current_msg.try(:task_id)))
+          if (task_id = (Thread.current["tracking_label"] || (defined?($_miq_worker_current_msg) && $_miq_worker_current_msg.try(:task_id))))
             prefix = "Q-task_id([#{task_id}])"
             msg = "#{prefix} #{msg}" unless msg.include?(prefix)
           end


### PR DESCRIPTION
Fixes:
```
manageiq-loggers-1.0.0/lib/manageiq/loggers/base.rb:154: warning: global variable `$_miq_worker_current_msg' not initialized
```

Note, this happens whenever we log anything so it's super noisy if you're trying to fix ruby deprecation warnings in 2.7 for features removed in ruby 3.0 😉 