### PR TITLE
Require active_support first

### DIFF
--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'active_support'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/string'

--- a/lib/manageiq/loggers/cloud_watch.rb
+++ b/lib/manageiq/loggers/cloud_watch.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/string'
 require 'active_support/logger'
 

--- a/spec/manageiq/base_spec.rb
+++ b/spec/manageiq/base_spec.rb
@@ -235,6 +235,7 @@ describe ManageIQ::Loggers::Base do
     end
 
     it "handles logging hash-like classes" do
+      require "active_support"
       require "active_support/core_ext/hash"
       hash = ActiveSupport::HashWithIndifferentAccess.new(:a => 1, :b => {:c => 3})
 


### PR DESCRIPTION
As of Rails 7, active_support must be required before requiring any specific
core extensions.

@jrafanie Please review.