### PR TITLE
Remove timestamp whitespace in container logger formatter

### DIFF
--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -53,6 +53,10 @@ module ManageIQ
 
         private
 
+        def format_datetime(*)
+          super.rstrip
+        end
+
         def hostname
           @hostname ||= ENV["HOSTNAME"]
         end

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Loggers::Container::Formatter do
 
   def expected_hash(time, message, request_id = nil)
     {
-      "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N "),
+      "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N"),
       "hostname"   => ENV["HOSTNAME"],
       "level"      => "info",
       "message"    => message,


### PR DESCRIPTION
For some reason, the default format_datetime method returns a string
with a tailing space, which is fine when put into a format string, but
is strange when standalone in a JSON output.

@agrare Please review.