### PR TITLE
Split out JSON logger from Container logger

### DIFF
--- a/lib/manageiq/loggers.rb
+++ b/lib/manageiq/loggers.rb
@@ -1,5 +1,8 @@
 require "manageiq/loggers/base"
+require "manageiq/loggers/json_logger"
+
 require "manageiq/loggers/cloud_watch"
 require "manageiq/loggers/container"
 require "manageiq/loggers/journald"
+
 require "manageiq/loggers/version"

--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -1,83 +1,13 @@
 module ManageIQ
   module Loggers
-    class Container < Base
-      def initialize(logdev = STDOUT, *args)
+    class Container < JSONLogger
+      def initialize(logdev = $stdout, *_, **_)
         logdev.sync = true # Don't buffer container log output
-
         super
-
-        self.formatter = Formatter.new
       end
 
       def filename
         "STDOUT"
-      end
-
-      class Formatter < Base::Formatter
-        SEVERITY_MAP = {
-          "DEBUG"   => "debug",
-          "INFO"    => "info",
-          "WARN"    => "warning",
-          "ERROR"   => "err",
-          "FATAL"   => "crit",
-          "UNKNOWN" => "unknown"
-          # Others that don't match up: alert emerg notice trace
-        }.freeze
-
-        def initialize
-          super
-          require 'json'
-        end
-
-        def call(severity, time, progname, msg)
-          # From https://github.com/ViaQ/elasticsearch-templates/releases -> Downloads -> *.asciidoc
-          # NOTE: These values are in a specific order for easier human readbility via STDOUT
-          payload = {
-            :@timestamp => format_datetime(time),
-            :hostname   => hostname,
-            :pid        => $PROCESS_ID,
-            :tid        => thread_id,
-            :service    => progname,
-            :level      => translate_error(severity),
-            :message    => prefix_task_id(msg2str(msg)),
-            :request_id => request_id
-            # :tags => "tags string",
-          }.compact
-          JSON.generate(payload) << "\n"
-        rescue Encoding::UndefinedConversionError
-          raise unless msg.encoding == Encoding::ASCII_8BIT
-
-          msg.force_encoding("UTF-8")
-          retry
-        end
-
-        private
-
-        def format_datetime(*)
-          super.rstrip
-        end
-
-        def hostname
-          @hostname ||= ENV["HOSTNAME"]
-        end
-
-        def thread_id
-          Thread.current.object_id.to_s(16)
-        end
-
-        def translate_error(level)
-          SEVERITY_MAP[level] || "unknown"
-        end
-
-        def request_id
-          Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
-            if request_id
-              require "active_support"
-              require "active_support/deprecation"
-              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
-            end
-          end
-        end
       end
     end
   end

--- a/lib/manageiq/loggers/json_logger.rb
+++ b/lib/manageiq/loggers/json_logger.rb
@@ -1,0 +1,77 @@
+module ManageIQ
+  module Loggers
+    class JSONLogger < Base
+     def initialize(*_, **_)
+        super
+        self.formatter = Formatter.new
+      end
+
+      class Formatter < Base::Formatter
+        SEVERITY_MAP = {
+          "DEBUG"   => "debug",
+          "INFO"    => "info",
+          "WARN"    => "warning",
+          "ERROR"   => "err",
+          "FATAL"   => "crit",
+          "UNKNOWN" => "unknown"
+          # Others that don't match up: alert emerg notice trace
+        }.freeze
+
+        def initialize
+          super
+          require 'json'
+        end
+
+        def call(severity, time, progname, msg)
+          # From https://github.com/ViaQ/elasticsearch-templates/releases -> Downloads -> *.asciidoc
+          # NOTE: These values are in a specific order for easier human readbility via STDOUT
+          payload = {
+            :@timestamp => format_datetime(time),
+            :hostname   => hostname,
+            :pid        => $PROCESS_ID,
+            :tid        => thread_id,
+            :service    => progname,
+            :level      => translate_error(severity),
+            :message    => prefix_task_id(msg2str(msg)),
+            :request_id => request_id
+            # :tags => "tags string",
+          }.compact
+          JSON.generate(payload) << "\n"
+        rescue Encoding::UndefinedConversionError
+          raise unless msg.encoding == Encoding::ASCII_8BIT
+
+          msg.force_encoding("UTF-8")
+          retry
+        end
+
+        private
+
+        def format_datetime(*)
+          super.rstrip
+        end
+
+        def hostname
+          @hostname ||= ENV["HOSTNAME"]
+        end
+
+        def thread_id
+          Thread.current.object_id.to_s(16)
+        end
+
+        def translate_error(level)
+          SEVERITY_MAP[level] || "unknown"
+        end
+
+        def request_id
+          Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
+            if request_id
+              require "active_support"
+              require "active_support/deprecation"
+              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -2,93 +2,15 @@ require "active_support"
 require "active_support/deprecation"
 require "active_support/json"
 
-describe ManageIQ::Loggers::Container::Formatter do
-  let(:message)   { "testing 1, 2, 3" }
-  let(:formatter) { described_class.new }
+describe ManageIQ::Loggers::Container do
+  let(:logger)  { described_class.new }
+  let(:message) { "testing 1, 2, 3" }
 
-  def expected_hash(time, message, request_id = nil)
-    {
-      "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N"),
-      "hostname"   => ENV["HOSTNAME"],
-      "level"      => "info",
-      "message"    => message,
-      "pid"        => $PROCESS_ID,
-      "service"    => "some_program",
-      "tid"        => Thread.current.object_id.to_s(16),
-      "request_id" => request_id
-    }.compact
+  it "writes to STDOUT by default" do
+    expect { logger.info(message) }.to output.to_stdout
   end
 
-  it "with a message" do
-    time = Time.now
-    result = formatter.call("INFO", time, "some_program", message)
-
-    expected = expected_hash(time, message)
-    expect(JSON.parse(result)).to eq(expected)
-  end
-
-  it "with a message with Unicode characters" do
-    message = "häåğēn.däzş"
-    time = Time.now
-    result = formatter.call("INFO", time, "some_program", message)
-
-    expected = expected_hash(time, message)
-    expect(JSON.parse(result)).to eq(expected)
-  end
-
-  it "with a message with ASCII-8BIT encoding" do
-    time = Time.now
-    result = formatter.call("INFO", time, "some_program", message.dup.force_encoding("ASCII-8BIT"))
-
-    expected = expected_hash(time, message)
-    expect(JSON.parse(result)).to eq(expected)
-  end
-
-  it "with a message with ASCII-8BIT encoding and Unicode characters" do
-    message = "häåğēn.däzş"
-    time = Time.now
-    result = formatter.call("INFO", time, "some_program", message.dup.force_encoding("ASCII-8BIT"))
-
-    expected = expected_hash(time, message)
-    expect(JSON.parse(result)).to eq(expected)
-  end
-
-  describe "with a request_id in thread local storage" do
-    let(:request_id) { "123" }
-
-    context "in :request_id" do
-      before { Thread.current[:request_id] = request_id }
-      after  { Thread.current[:request_id] = nil }
-
-      it do
-        time = Time.now
-        result = formatter.call("INFO", time, "some_program", message)
-
-        expected = expected_hash(time, message, request_id)
-        expect(JSON.parse(result)).to eq(expected)
-      end
-    end
-
-    context "in deprecated :current_request" do
-      before { Thread.current[:current_request] = double(:request_id => request_id) }
-      after  { Thread.current[:current_request] = nil }
-
-      it do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
-
-        time = Time.now
-        result = formatter.call("INFO", time, "some_program", message)
-
-        expected = expected_hash(time, message, request_id)
-        expect(JSON.parse(result)).to eq(expected)
-      end
-    end
-  end
-
-  it "does not escape characters as in ActiveSupport::JSON extensions" do
-    time = Time.now
-    result = formatter.call("INFO", time, "some_program", "xxx < yyy > zzz")
-
-    expect(result).to include('"message":"xxx < yyy > zzz"')
+  it "#filename" do
+    expect(logger.filename).to eq("STDOUT")
   end
 end

--- a/spec/manageiq/json_logger_formatter_spec.rb
+++ b/spec/manageiq/json_logger_formatter_spec.rb
@@ -1,0 +1,94 @@
+require "active_support"
+require "active_support/deprecation"
+require "active_support/json"
+
+describe ManageIQ::Loggers::JSONLogger::Formatter do
+  let(:message)   { "testing 1, 2, 3" }
+  let(:formatter) { described_class.new }
+
+  def expected_hash(time, message, request_id = nil)
+    {
+      "@timestamp" => time.strftime("%Y-%m-%dT%H:%M:%S.%6N"),
+      "hostname"   => ENV["HOSTNAME"],
+      "level"      => "info",
+      "message"    => message,
+      "pid"        => $PROCESS_ID,
+      "service"    => "some_program",
+      "tid"        => Thread.current.object_id.to_s(16),
+      "request_id" => request_id
+    }.compact
+  end
+
+  it "with a message" do
+    time = Time.now
+    result = formatter.call("INFO", time, "some_program", message)
+
+    expected = expected_hash(time, message)
+    expect(JSON.parse(result)).to eq(expected)
+  end
+
+  it "with a message with Unicode characters" do
+    message = "häåğēn.däzş"
+    time = Time.now
+    result = formatter.call("INFO", time, "some_program", message)
+
+    expected = expected_hash(time, message)
+    expect(JSON.parse(result)).to eq(expected)
+  end
+
+  it "with a message with ASCII-8BIT encoding" do
+    time = Time.now
+    result = formatter.call("INFO", time, "some_program", message.dup.force_encoding("ASCII-8BIT"))
+
+    expected = expected_hash(time, message)
+    expect(JSON.parse(result)).to eq(expected)
+  end
+
+  it "with a message with ASCII-8BIT encoding and Unicode characters" do
+    message = "häåğēn.däzş"
+    time = Time.now
+    result = formatter.call("INFO", time, "some_program", message.dup.force_encoding("ASCII-8BIT"))
+
+    expected = expected_hash(time, message)
+    expect(JSON.parse(result)).to eq(expected)
+  end
+
+  describe "with a request_id in thread local storage" do
+    let(:request_id) { "123" }
+
+    context "in :request_id" do
+      before { Thread.current[:request_id] = request_id }
+      after  { Thread.current[:request_id] = nil }
+
+      it do
+        time = Time.now
+        result = formatter.call("INFO", time, "some_program", message)
+
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+
+    context "in deprecated :current_request" do
+      before { Thread.current[:current_request] = double(:request_id => request_id) }
+      after  { Thread.current[:current_request] = nil }
+
+      it do
+        expect(ActiveSupport::Deprecation).to receive(:warn)
+
+        time = Time.now
+        result = formatter.call("INFO", time, "some_program", message)
+
+        expected = expected_hash(time, message, request_id)
+        expect(JSON.parse(result)).to eq(expected)
+      end
+    end
+  end
+
+  it "does not escape characters as in ActiveSupport::JSON extensions" do
+    time = Time.now
+    result = formatter.call("INFO", time, "some_program", "xxx < yyy > zzz")
+
+    expect(result).to include('"message":"xxx < yyy > zzz"')
+  end
+end

--- a/spec/manageiq/json_logger_spec.rb
+++ b/spec/manageiq/json_logger_spec.rb
@@ -1,0 +1,40 @@
+describe ManageIQ::Loggers::JSONLogger do
+  let(:buffer)  { StringIO.new }
+  let(:logger)  { described_class.new(buffer) }
+  let(:message) { "testing 1, 2, 3" }
+
+  it "logs a message in JSON format" do
+    logger.info(message)
+
+    parsed = JSON.parse(buffer.string)
+    expected = {
+      "@timestamp" => a_string_matching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}$/),
+      "pid"        => $PROCESS_ID,
+      "tid"        => Thread.current.object_id.to_s(16),
+      "level"      => "info",
+      "message"    => "testing 1, 2, 3",
+    }
+
+    expect(parsed).to      match(expected)
+    expect(parsed.keys).to eq(expected.keys) # Verifying the key order and no extra keys
+  end
+
+  it "logs service if available" do
+    logger.progname = "some service"
+
+    logger.info(message)
+
+    parsed = JSON.parse(buffer.string)
+    expected = {
+      "@timestamp" => a_string_matching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}$/),
+      "pid"        => $PROCESS_ID,
+      "tid"        => Thread.current.object_id.to_s(16),
+      "service"    => "some service",
+      "level"      => "info",
+      "message"    => "testing 1, 2, 3",
+    }
+
+    expect(parsed).to      match(expected)
+    expect(parsed.keys).to eq(expected.keys) # Verifying the key order and no extra keys
+  end
+end


### PR DESCRIPTION
This allows us to later reuse the JSON logging for other purposes and
detaches it from container specifics

@agrare Please review.