### PR TITLE
Allow passing the CW logger's configuration as kwargs

### DIFF
--- a/lib/manageiq/loggers/cloud_watch.rb
+++ b/lib/manageiq/loggers/cloud_watch.rb
@@ -7,11 +7,11 @@ module ManageIQ
     class CloudWatch < Base
       NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace".freeze
 
-      def self.new(*args)
-        access_key_id     = ENV["CW_AWS_ACCESS_KEY_ID"].presence
-        secret_access_key = ENV["CW_AWS_SECRET_ACCESS_KEY"].presence
-        log_group_name    = ENV["CLOUD_WATCH_LOG_GROUP"].presence
-        log_stream_name   = ENV["HOSTNAME"].presence
+      def self.new(*args, access_key_id: nil, secret_access_key: nil, log_group: nil, hostname: nil)
+        access_key_id     ||= ENV["CW_AWS_ACCESS_KEY_ID"].presence
+        secret_access_key ||= ENV["CW_AWS_SECRET_ACCESS_KEY"].presence
+        log_group_name    ||= ENV["CLOUD_WATCH_LOG_GROUP"].presence
+        log_stream_name   ||= ENV["HOSTNAME"].presence
 
         container_logger = ManageIQ::Loggers::Container.new
         return container_logger unless access_key_id && secret_access_key && log_group_name && log_stream_name


### PR DESCRIPTION
Hey folks, long time no see :smile: 

We're happily using your logger, but got some issues with setting environment variables in certain contexts. Would it be possible to allow an alternative consumption of the params below instead of the ENV variables?

@Fryguy :wave: 