### PR TITLE
Fix missing ActiveSupport::Logger.broadcast

### DIFF
--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport",     ">= 5.0"
+  spec.add_runtime_dependency "activesupport",     ">= 5.0", "< 7.1"
   spec.add_runtime_dependency "manageiq-password", "< 2"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
ActiveSupport 7.1 both removed `ActiveSupport::Logger.broadcast` and introduced `BroadcastLogger` in the same release.  In order to support both <7.1 and >=7.1 we'll need to special case based on the version of activesupport.

For now this limits active_support to <7.1 and support will be added in a future release