### PR TITLE
Add a wrap method to support BroadcastLogger/ActiveSupport::Logger.broadcast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
         rails-version:
         - '6.1'
         - '7.0'
+        - '7.1'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,10 @@ minimum_version =
   case ENV['TEST_RAILS_VERSION']
   when "6.1"
     "~>6.1.7"
-  else
+  when "7.0"
     "~>7.0.8"
+  else
+    "~>7.1.4"
   end
 
 gem "activesupport", minimum_version

--- a/lib/manageiq/loggers/cloud_watch.rb
+++ b/lib/manageiq/loggers/cloud_watch.rb
@@ -1,5 +1,5 @@
 require 'active_support'
-require 'active_support/core_ext/string'
+require 'active_support/core_ext/object'
 require 'active_support/logger'
 
 module ManageIQ
@@ -20,7 +20,8 @@ module ManageIQ
 
         creds = {:access_key_id => access_key_id, :secret_access_key => secret_access_key}
         cloud_watch_logdev = CloudWatchLogger::Client.new(creds, log_group, log_stream)
-        super(cloud_watch_logdev).tap { |logger| logger.extend(ActiveSupport::Logger.broadcast(container_logger)) }
+        cloud_watch_logger = super(cloud_watch_logdev)
+        cloud_watch_logger.wrap(container_logger)
       end
 
       def initialize(logdev, *args)

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -40,7 +40,13 @@ module ManageIQ
         end
 
         message = formatter.call(format_severity(severity), nil, progname, message)
-        caller_object = caller_locations(3, 1).first
+
+        # The call stack is different depending on if we are using the newer
+        # ActiveSupport::BroadcastLogger or the older ActiveSupport::Logger.broadcast
+        # so we have to account for that difference when walking up the caller_locations
+        # to get the "real" logging location.
+        callstack_start = ActiveSupport.gem_version >= Gem::Version.new("7.1.0") ? 7 : 3
+        caller_object = caller_locations(callstack_start, 1).first
 
         Systemd::Journal.message(
           :message           => message,

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport",     ">= 5.0", "< 7.1"
+  spec.add_runtime_dependency "activesupport",     ">= 5.0"
   spec.add_runtime_dependency "manageiq-password", "< 2"
 
   spec.add_development_dependency "bundler"

--- a/spec/manageiq/cloud_watch_spec.rb
+++ b/spec/manageiq/cloud_watch_spec.rb
@@ -25,10 +25,6 @@ describe ManageIQ::Loggers::CloudWatch do
       expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new).and_return(double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager", :deliver => nil))
     end
 
-    it "returns a CloudWatch::Client" do
-      expect(described_class.new).to be_kind_of(ManageIQ::Loggers::CloudWatch)
-    end
-
     it "the Container logger also receives the same messages" do
       container_logger = ManageIQ::Loggers::Container.new
       expect(ManageIQ::Loggers::Container).to receive(:new).and_return(container_logger)
@@ -51,10 +47,6 @@ describe ManageIQ::Loggers::CloudWatch do
 
     before do
       expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new).and_return(double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager", :deliver => nil))
-    end
-
-    it "returns a CloudWatch::Client" do
-      expect(described_class.new(**params)).to be_kind_of(ManageIQ::Loggers::CloudWatch)
     end
 
     it "the Container logger also receives the same messages" do

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
 
   context "code_file" do
     it "sets the code_file" do
-      log = Logger.new(IO::NULL)
-      log.extend(ActiveSupport::Logger.broadcast(logger))
+      log = logger.wrap(Logger.new(IO::NULL))
 
       expect(Systemd::Journal).to receive(:message).with(hash_including(:code_file => __FILE__, :code_line => __LINE__ + 1))
       log.info("abcd") # NOTE this has to be exactly beneath the exect for the __LINE__ + 1 to work


### PR DESCRIPTION
Rails has removed support for `ActiveSupport::Logger.broadcast` in the same release they added a `ActiveSupport::BroadcastLogger`.  This means in order to support both active_support < 7.1 and active_support >= 7.1 we need to special case this based on the gem version

TODO:
- [x] journald logger caller_locations is going to be different if called directly, from BroadcastLogger, or from Loggers.broadcast