### PR TITLE
Bump manageiq-style to >=1.5.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'

--- a/manageiq-loggers.gemspec
+++ b/manageiq-loggers.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "cloudwatchlogger"
-  spec.add_development_dependency "manageiq-style"
+  spec.add_development_dependency "manageiq-style", ">= 1.5.2"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
manageiq-style 1.5.2 requires rubocop 1.56.3, which, in turn, requires
Ruby >= 2.7. Thus, this commit also drops support for Ruby 2.6

This should resolve some of the Mend issues.

@jrafanie and @agrare Please review.  I'm not sure if this should get released as a 2.0 because of the Ruby 2.6 drop. Thoughts?