### PR TITLE
Add ManageIQ::Loggers.deprecator

### DIFF
--- a/lib/manageiq/loggers.rb
+++ b/lib/manageiq/loggers.rb
@@ -6,3 +6,11 @@ require "manageiq/loggers/container"
 require "manageiq/loggers/journald"
 
 require "manageiq/loggers/version"
+
+module ManageIQ
+  module Loggers
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new(VERSION, "ManageIQ::Loggers")
+    end
+  end
+end

--- a/lib/manageiq/loggers/json_logger.rb
+++ b/lib/manageiq/loggers/json_logger.rb
@@ -65,9 +65,9 @@ module ManageIQ
         def request_id
           Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
             if request_id
-              require "active_support"
-              require "active_support/deprecation"
-              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
+              ManageIQ::Loggers.deprecator.warn(
+                "Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically."
+              )
             end
           end
         end

--- a/spec/manageiq/json_logger_formatter_spec.rb
+++ b/spec/manageiq/json_logger_formatter_spec.rb
@@ -74,7 +74,7 @@ describe ManageIQ::Loggers::JSONLogger::Formatter do
       after  { Thread.current[:current_request] = nil }
 
       it do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
+        expect(ManageIQ::Loggers.deprecator).to receive(:warn)
 
         time = Time.now
         result = formatter.call("INFO", time, "some_program", message)


### PR DESCRIPTION
Rails 7.1 deprecated `ActiveSupport::Deprecation.warn` and removed it in 7.2
https://github.com/rails/rails/pull/47354
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
