### PR TITLE
CloudWatch logger should let the caller choose broadcast logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- **BREAKING** Drop automatic broadcast of Cloudwatch to Container logger [(#79)](https://github.com/ManageIQ/manageiq-loggers/pull/79)
 
 ## [1.2.0] - 2024-09-30
 ### Added

--- a/lib/manageiq/loggers/cloud_watch.rb
+++ b/lib/manageiq/loggers/cloud_watch.rb
@@ -13,15 +13,13 @@ module ManageIQ
         log_group         ||= ENV["CLOUD_WATCH_LOG_GROUP"].presence
         log_stream        ||= ENV["HOSTNAME"].presence
 
-        container_logger = ManageIQ::Loggers::Container.new
-        return container_logger unless access_key_id && secret_access_key && log_group && log_stream
+        raise ArgumentError, "Required parameters: access_key_id, secret_access_key, log_group, log_stream" unless access_key_id && secret_access_key && log_group && log_stream
 
         require 'cloudwatchlogger'
 
         creds = {:access_key_id => access_key_id, :secret_access_key => secret_access_key}
         cloud_watch_logdev = CloudWatchLogger::Client.new(creds, log_group, log_stream)
-        cloud_watch_logger = super(cloud_watch_logdev)
-        cloud_watch_logger.wrap(container_logger)
+        super(cloud_watch_logdev)
       end
 
       def initialize(logdev, *args)

--- a/spec/manageiq/cloud_watch_spec.rb
+++ b/spec/manageiq/cloud_watch_spec.rb
@@ -1,8 +1,10 @@
 require 'cloudwatchlogger'
 
 describe ManageIQ::Loggers::CloudWatch do
-  it "unconfigured returns a Container logger" do
-    expect(described_class.new).to be_kind_of(ManageIQ::Loggers::Container)
+  let(:cloud_watch_logdev) { double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager") }
+
+  it "raises an exception if cloudwatch parameters are missing" do
+    expect { described_class.new }.to raise_error(ArgumentError, /Required parameters: access_key_id, secret_access_key, log_group, log_stream/)
   end
 
   context "configured via env" do
@@ -22,15 +24,13 @@ describe ManageIQ::Loggers::CloudWatch do
     end
 
     before do
-      expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new).and_return(double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager", :deliver => nil))
+      expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager)
+        .to receive(:new)
+        .and_return(cloud_watch_logdev)
     end
 
-    it "the Container logger also receives the same messages" do
-      container_logger = ManageIQ::Loggers::Container.new
-      expect(ManageIQ::Loggers::Container).to receive(:new).and_return(container_logger)
-
-      expect(container_logger).to receive(:add).with(1, nil, "Testing 1,2,3")
-
+    it "calls deliver on the CloudWatch logger" do
+      expect(cloud_watch_logdev).to receive(:deliver).with(a_string_matching("\"level\":\"info\",\"message\":\"Testing 1,2,3\""))
       described_class.new.info("Testing 1,2,3")
     end
   end
@@ -46,15 +46,13 @@ describe ManageIQ::Loggers::CloudWatch do
     end
 
     before do
-      expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new).and_return(double("CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager", :deliver => nil))
+      expect(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager)
+        .to receive(:new)
+        .and_return(cloud_watch_logdev)
     end
 
-    it "the Container logger also receives the same messages" do
-      container_logger = ManageIQ::Loggers::Container.new
-      expect(ManageIQ::Loggers::Container).to receive(:new).and_return(container_logger)
-
-      expect(container_logger).to receive(:add).with(1, nil, "Testing 1,2,3")
-
+    it "calls deliver on the CloudWatch logger" do
+      expect(cloud_watch_logdev).to receive(:deliver).with(a_string_matching("\"level\":\"info\",\"message\":\"Testing 1,2,3\""))
       described_class.new(**params).info("Testing 1,2,3")
     end
   end


### PR DESCRIPTION
Re: https://github.com/ManageIQ/manageiq-loggers/pull/63#discussion_r1781264948

This would be a breaking change but I do think it this is the right way to go in the long run and is more obvious/direct in its behavior.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
