### PR TITLE
Drop the deprecated current_request.request_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- **BREAKING** Remove the deprecated `current_request.request_id` [(#80)](https://github.com/ManageIQ/manageiq-loggers/pull/80)
 
 ## [1.2.0] - 2024-09-30
 ### Added

--- a/lib/manageiq/loggers/json_logger.rb
+++ b/lib/manageiq/loggers/json_logger.rb
@@ -63,13 +63,7 @@ module ManageIQ
         end
 
         def request_id
-          Thread.current[:request_id] || Thread.current[:current_request]&.request_id.tap do |request_id|
-            if request_id
-              require "active_support"
-              require "active_support/deprecation"
-              ActiveSupport::Deprecation.warn("Usage of `Thread.current[:current_request]&.request_id` will be deprecated in version 0.5.0. Please switch to `Thread.current[:request_id]` to log request_id automatically.")
-            end
-          end
+          Thread.current[:request_id]
         end
       end
     end

--- a/spec/manageiq/json_logger_formatter_spec.rb
+++ b/spec/manageiq/json_logger_formatter_spec.rb
@@ -68,21 +68,6 @@ describe ManageIQ::Loggers::JSONLogger::Formatter do
         expect(JSON.parse(result)).to eq(expected)
       end
     end
-
-    context "in deprecated :current_request" do
-      before { Thread.current[:current_request] = double(:request_id => request_id) }
-      after  { Thread.current[:current_request] = nil }
-
-      it do
-        expect(ActiveSupport::Deprecation).to receive(:warn)
-
-        time = Time.now
-        result = formatter.call("INFO", time, "some_program", message)
-
-        expected = expected_hash(time, message, request_id)
-        expect(JSON.parse(result)).to eq(expected)
-      end
-    end
   end
 
   it "does not escape characters as in ActiveSupport::JSON extensions" do


### PR DESCRIPTION
`ActiveSupport::Deprecation.warn` was removed in activesupport 7.2, and this has been deprecated for a number of releases including 1 major release.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
