### PR TITLE
Fix Logger subclasses providing no default logdev

### DIFF
--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -23,7 +23,7 @@ module ManageIQ
         end
       end
 
-      def initialize(*_, **_)
+      def initialize(_logdev = nil, *_, **_)
         super
         self.level = INFO
 

--- a/lib/manageiq/loggers/json_logger.rb
+++ b/lib/manageiq/loggers/json_logger.rb
@@ -1,7 +1,7 @@
 module ManageIQ
   module Loggers
     class JSONLogger < Base
-     def initialize(*_, **_)
+     def initialize(_logdev = nil, *_, **_)
         super
         self.formatter = Formatter.new
       end

--- a/spec/manageiq/base_spec.rb
+++ b/spec/manageiq/base_spec.rb
@@ -10,6 +10,10 @@ describe ManageIQ::Loggers::Base do
     described_class.instance_variable_set("@log_hashes_filter", nil)
   end
 
+  it "provides nil default log device" do
+    expect(described_class.new.logdev).to eq nil
+  end
+
   it "logs a message" do
     logger.info(message)
 

--- a/spec/manageiq/container_spec.rb
+++ b/spec/manageiq/container_spec.rb
@@ -6,6 +6,10 @@ describe ManageIQ::Loggers::Container do
   let(:logger)  { described_class.new }
   let(:message) { "testing 1, 2, 3" }
 
+  it "provides a default log device" do
+    expect(described_class.new.logdev).to be_kind_of(Logger::LogDevice)
+  end
+
   it "writes to STDOUT by default" do
     expect { logger.info(message) }.to output.to_stdout
   end

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe ManageIQ::Loggers::Journald, :linux do
   let(:logger) { described_class.new }
 
+  it "provides nil default log device" do
+    expect(described_class.new.logdev).to eq nil
+  end
+
   context "progname" do
     it "sets the progname to manageiq by default" do
       expect(logger.progname).to eq("manageiq")

--- a/spec/manageiq/json_logger_spec.rb
+++ b/spec/manageiq/json_logger_spec.rb
@@ -3,6 +3,10 @@ describe ManageIQ::Loggers::JSONLogger do
   let(:logger)  { described_class.new(buffer) }
   let(:message) { "testing 1, 2, 3" }
 
+  it "provides nil default log device" do
+    expect(described_class.new.logdev).to eq nil
+  end
+
   it "logs a message in JSON format" do
     logger.info(message)
 


### PR DESCRIPTION
Logger.new requires a log device as the first argument.

Normalized the other loggers to match the Logger#initialize interface for consistency.

Fixes the following bug:

irb(main):001> ManageIQ::Loggers::Base.new
xxx/.rubies/ruby-3.3.6/lib/ruby/3.3.0/logger.rb:578:in `initialize': wrong number of arguments (given 0, expected 1..3) (ArgumentError)
	from manageiq-loggers (1.2.0) lib/manageiq/loggers/base.rb:27:in `initialize'

irb(main):002> ManageIQ::Loggers::JSONLogger.new
xxx/.rubies/ruby-3.3.6/lib/ruby/3.3.0/logger.rb:578:in `initialize': wrong number of arguments (given 0, expected 1..3) (ArgumentError)
	from manageiq-loggers (1.2.0) lib/manageiq/loggers/base.rb:27:in `initialize'
	from manageiq-loggers (1.2.0) lib/manageiq/loggers/json_logger.rb:5:in `initialize'

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
