### PR TITLE
Handle a nil caller_object in journald loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - **BREAKING** Remove the Cloudwatch Logger [(#81)](https://github.com/ManageIQ/manageiq-loggers/pull/81)
 
+### Fixed
+- Handle nil caller_object in Journald logger [(#91)](https://github.com/ManageIQ/manageiq-loggers/pull/91)
+
 ## [1.2.0] - 2024-09-30
 ### Added
 - Test with ruby 3.1 and 3.0 [(#65)](https://github.com/ManageIQ/manageiq-loggers/pull/65)

--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -46,15 +46,15 @@ module ManageIQ
         # so we have to account for that difference when walking up the caller_locations
         # to get the "real" logging location.
         callstack_start = ActiveSupport.gem_version >= Gem::Version.new("7.1.0") ? 7 : 3
-        caller_object = caller_locations(callstack_start, 1).first
+        caller_object = caller_locations(callstack_start, 1)&.first
 
         Systemd::Journal.message(
           :message           => message,
           :priority          => log_level_map[severity],
           :syslog_identifier => progname,
-          :code_line         => caller_object.lineno,
-          :code_file         => caller_object.absolute_path,
-          :code_func         => caller_object.label
+          :code_line         => caller_object&.lineno,
+          :code_file         => caller_object&.absolute_path,
+          :code_func         => caller_object&.label
         )
       end
 

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ManageIQ::Loggers::Journald, :linux do
+  require "systemd-journal"
+
   let(:logger) { described_class.new }
 
   context "progname" do
@@ -18,11 +20,18 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
   end
 
   context "code_file" do
-    it "sets the code_file" do
-      log = logger.wrap(Logger.new(IO::NULL))
-
+    xit "sets the code_file" do
       expect(Systemd::Journal).to receive(:message).with(hash_including(:code_file => __FILE__, :code_line => __LINE__ + 1))
-      log.info("abcd") # NOTE this has to be exactly beneath the exect for the __LINE__ + 1 to work
+      logger.info("abcd") # NOTE this has to be exactly beneath the exect for the __LINE__ + 1 to work
+    end
+
+    context "with a wrapped logger" do
+      let(:log) { logger.wrap(Logger.new(IO::NULL)) }
+
+      it "sets the code_file" do
+        expect(Systemd::Journal).to receive(:message).with(hash_including(:code_file => __FILE__, :code_line => __LINE__ + 1))
+        log.info("abcd") # NOTE this has to be exactly beneath the exect for the __LINE__ + 1 to work
+      end
     end
   end
 end


### PR DESCRIPTION
Depending on the way the logger is invoked (e.g. via a broadcast logger or not) the call stack is different.

If the caller_object is nil this was throwing an exception instead of just not setting the code_{line,file,func} properties of the `Systemd::Journal` message.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
