### PR TITLE
Determine caller location dynamically

### DIFF
--- a/lib/manageiq/loggers/journald.rb
+++ b/lib/manageiq/loggers/journald.rb
@@ -45,8 +45,11 @@ module ManageIQ
         # ActiveSupport::BroadcastLogger or the older ActiveSupport::Logger.broadcast
         # so we have to account for that difference when walking up the caller_locations
         # to get the "real" logging location.
-        callstack_start = ActiveSupport.gem_version >= Gem::Version.new("7.1.0") ? 7 : 3
-        caller_object = caller_locations(callstack_start, 1)&.first
+        caller_object = caller_locations.detect do |caller_loc|
+          next if caller_loc.path.end_with?("lib/active_support/broadcast_logger.rb", "lib/active_support/logger.rb", "/logger.rb")
+
+          caller_loc
+        end
 
         Systemd::Journal.message(
           :message           => message,

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ManageIQ::Loggers::Journald, :linux do
   end
 
   context "code_file" do
-    xit "sets the code_file" do
+    it "sets the code_file" do
       expect(Systemd::Journal).to receive(:message).with(hash_including(:code_file => __FILE__, :code_line => __LINE__ + 1))
       logger.info("abcd") # NOTE this has to be exactly beneath the exect for the __LINE__ + 1 to work
     end


### PR DESCRIPTION
Since it is up to the caller how the logger is invoked (e.g. directly or via a broadcast logger) we can't simply hard code the number of steps up the callstack to skip.

This attempts to dynamically determine the caller location.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
