### PR TITLE
Update ci matrix primarily for rails 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,13 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
-        - '3.0'
         - '3.1'
         - '3.2'
         - '3.3'
+        - '3.4'
         rails-version:
-        - '6.1'
-        - '7.0'
         - '7.1'
+        - '7.2'
     env:
       TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -34,6 +32,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v9

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,10 @@ gemspec
 
 minimum_version =
   case ENV['TEST_RAILS_VERSION']
-  when "6.1"
-    "~>6.1.7"
-  when "7.0"
-    "~>7.0.8"
+  when "7.2"
+    "~>7.2.2"
   else
-    "~>7.1.4"
+    "~>7.1.5"
   end
 
 gem "activesupport", minimum_version

--- a/spec/manageiq/journald_spec.rb
+++ b/spec/manageiq/journald_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe ManageIQ::Loggers::Journald, :linux do
-  require "systemd-journal"
-
-  let(:logger) { described_class.new }
+  let!(:logger) { described_class.new }
 
   context "progname" do
     it "sets the progname to manageiq by default" do


### PR DESCRIPTION
### Ruby: Add 3.4/Drop 3.0 and older, add rails 7.2, drop 7.0 and older

Note, ruby 3.4 with rails 7.0 evokes this warning.  We can maintain 7.0 with 3.4 if we add mutex_m to our gemspec
until we can drop rails 7.0:

```
...gems/activesupport-7.0.8.7/lib/active_support/notifications/fanout.rb:3: warning: mutex_m was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
```

### Remove require outside of test, let initialize do it

Today I learned that filtering specs by "linux" still runs code outside of
tests. Code within the describe block is still evaluated before the tests
within it are excluded.  The require needs to be done within a let, before, or
an example. Instead, we can let the initialize do the require and make sure
that is run first by changing it to let!.